### PR TITLE
fix scriptcraft download link

### DIFF
--- a/trainingsanleitungen/minecraft-plugins/07_spigot_scriptcraft_docker/base-image/Dockerfile
+++ b/trainingsanleitungen/minecraft-plugins/07_spigot_scriptcraft_docker/base-image/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /tmp/spigotmc \
 RUN cd /bin/spigotmc \
     && mkdir plugins \
     && mkdir -p /scriptcraft/plugins \
-    && curl -o plugins/scriptcraft.jar http://scriptcraftjs.org/download/latest/scriptcraft-3.2.0/scriptcraft.jar
+    && curl -o plugins/scriptcraft.jar https://scriptcraftjs.org/download/latest/scriptcraft-3.2.1/scriptcraft.jar
 
 WORKDIR /bin/spigotmc
 


### PR DESCRIPTION
they don't allow https and removed the 3.2.0 version which resulted in a scriptcraft.jar containing an 301 html error...