### PR TITLE
Fix category filters in firefox

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -114,8 +114,6 @@ function selectCategory(category) {
 
   $('.category-cards .category').hide();
   $('.category-cards .' + category).show();
-
-  return false;
 }
 
 function loadEventsOverview(eventsTable) {


### PR DESCRIPTION
When the expression in `href="javascript: <expression>"` returns something, the entire site is switched out for the content in Firefox.


https://github.com/coderdojo-linz/coderdojo-linz.github.io/assets/63104422/55515e07-e651-4aab-881c-f464a420ac02

I'm uncertain about the reason for `return false` in the first place, we may want to check that and make sure this doesn't introduce a regression before merging.